### PR TITLE
Update discovery.js

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -348,6 +348,8 @@ function mixinDiscovery(MySQL) {
             case 'TIMESTAMP':
             case 'DATETIME':
                 return 'Date';
+            case 'POINT'
+                return 'GeoPoint';
             default:
                 return 'String';
         }


### PR DESCRIPTION
The issue is with the Discovery of Models. MYSQL Fields of Type 'POINT' are being discovered but loopback LDL model field provided by discovery functions is being of type 'String'.

missing code: case 'POINT': return 'GeoPoint';

for further information:
https://github.com/strongloop/loopback-connector-mysql/issues/17
