### PR TITLE
Prevent inserting undefined values

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -215,9 +215,13 @@ MySQL.prototype.updateOrCreate = function (model, data, callback) {
       } else {
         v = data[key];
       }
-      fieldsNames.push(k);
-      fieldValues.push(v);
-      if (!mysql.id(model, key)) combined.push(k + ' = ' + v);
+      if (v !== undefined) {
+        fieldsNames.push(k);
+        fieldValues.push(v);
+        if (!mysql.id(model, key)) {
+          combined.push(k + ' = ' + v);
+        }
+      }
     }
   });
 


### PR DESCRIPTION
The following SQL query was executed:

``` sql
INSERT INTO `cv` (`first_name`, `last_name`, `father_name`, `city`, `district`, `transfer`, `nationality`, `email`, `icq`, `skype`, `birth_date`, `marital_status`, `gender`, `children_status`, `id`) VALUES ('asdsd', , , '', '', , , 'i@marat.by', , , , , , , 2) ON DUPLICATE KEY UPDATE `first_name` = 'asdsd', `last_name` = undefined, `father_name` = undefined, `city` = '', `district` = '', `transfer` = undefined, `nationality` = undefined, `email` = 'i@marat.by', `icq` = undefined, `skype` = undefined, `birth_date` = undefined, `marital_status` = undefined, `gender` = undefined, `children_status` = undefined;
```
