### PR TITLE
updateOrCreate assumes numeric primary key(s)

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -213,11 +213,7 @@ MySQL.prototype.updateOrCreate = function (model, data, callback) {
     if (props[key] || mysql.id(model, key)) {
       var k = mysql.columnEscaped(model, key);
       var v;
-      if (!mysql.id(model, key)) {
-        v = mysql.toDatabase(props[key], data[key]);
-      } else {
-        v = data[key];
-      }
+      v = mysql.toDatabase(props[key], data[key]);
       if (v !== undefined) {
         fieldsNames.push(k);
         fieldValues.push(v);


### PR DESCRIPTION
I removed the check to see if a property is an ID field while building the
values clause to allow it to work if primary key(s) are strings.

This is easily tested by creating a table + model with a string primary key and use the create
endpoint in the explorer, then copy the same JSON object into the createOrUpdate PUT 
request to see it fail before the change. The generated SQL is wrong (values not escaped).
