### PR TITLE
Remove peer dependency on datasource-juggler

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -3,7 +3,7 @@
  */
 var mysql = require('mysql');
 
-var juggler = require('loopback-datasource-juggler');
+var SqlConnector = require('loopback-connector').SqlConnector;
 var EnumFactory = require('./enumFactory').EnumFactory;
 
 var debug = require('debug')('loopback:connector:mysql');
@@ -69,9 +69,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   dataSource.connector = new MySQL(dataSource.client, s);
   dataSource.connector.dataSource = dataSource;
 
-  // MySQL specific column types
-  juggler.ModelBuilder.registerType(function Point() {
-  });
+  defineMySQLTypes(dataSource);
 
   dataSource.EnumFactory = EnumFactory; // factory for Enums. Note that currently Enums can not be registered.
 
@@ -81,6 +79,21 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
 };
 
 exports.MySQL = MySQL;
+
+function defineMySQLTypes(dataSource) {
+  var modelBuilder = dataSource.modelBuilder;
+  var defineType = modelBuilder.defineValueType ?
+    // loopback-datasource-juggler 2.x
+    modelBuilder.defineValueType.bind(modelBuilder) :
+    // loopback-datasource-juggler 1.x
+    modelBuilder.constructor.registerType.bind(modelBuilder.constructor);
+
+  // The Point type is inherited from jugglingdb mysql adapter.
+  // LoopBack uses GeoPoint instead.
+  // The Point type can be removed at some point in the future.
+  defineType(function Point() {
+  });
+}
 
 /**
  * @constructor
@@ -94,7 +107,7 @@ function MySQL(client, settings) {
   this.settings = settings;
 }
 
-require('util').inherits(MySQL, juggler.BaseSQL);
+require('util').inherits(MySQL, SqlConnector);
 
 /**
  * Execute the sql statement

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "mocha"
   },
   "dependencies": {
+    "loopback-connector": "1.x",
     "mysql": "~2.3.0",
     "async": "~0.9.0",
     "debug": "~0.8.0"


### PR DESCRIPTION
Use `SqlConnector` from loopback-connector as the base class for the
MySQL connector.

Use `dataSource.modelBuilder` instead of `juggler.ModelBuilder` to
access the function for registering new schema type.

Note: the behaviour remains backwards compatible, the connector can be
used with both old 1.x and upcoming 2.x versions of
loopback-datasource-juggler.

Requires strongloop/loopback-connector#2.

/to @raymondfeng @ritch please review

strongloop/loopback#275
