### PR TITLE
fix: build foreign key definition

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -599,10 +599,12 @@ function mixinMigration(MySQL, mysql) {
 
       // verify that the other model in the same DB
       if (this._models[fkEntityName]) {
+        const definitionFkEntityName = this.getModelDefinition(fkEntityName);
+
         let constraint = ' CONSTRAINT ' + this.client.escapeId(fk.name) +
           ' FOREIGN KEY (`' + expectedColNameForModel(fk.foreignKey, definition) + '`)' +
           ' REFERENCES ' + this.tableEscaped(fkEntityName) +
-          '(' + this.client.escapeId(fk.entityKey) + ')';
+          '(`' + expectedColNameForModel(fk.entityKey, definitionFkEntityName) + '`)';
         if (fk.onDelete) {
           constraint += ' ON DELETE ' + fk.onDelete.toUpperCase();
         }


### PR DESCRIPTION
Signed-off-by: Caique Pimenta <cpimenta.apsoftware@gmail.com>

Use of the existing method "expectedColNameForModel" for get the custom name of a column referenced from a foreign key on build foreign key definition.

Fixes #441 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
