### PR TITLE
feat: avoid 'USING ' on FULLTEXT index

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -369,7 +369,7 @@ function mixinMigration(MySQL, mysql) {
         const indexName = self.client.escapeId(propName);
         let type = '';
         let kind = '';
-        if (i.type) {
+        if (i.type && i.kind.toUpperCase() !== 'FULLTEXT') {
           type = 'USING ' + i.type;
         }
         if (kind && type) {
@@ -393,7 +393,7 @@ function mixinMigration(MySQL, mysql) {
         const iName = self.client.escapeId(indexName);
         let type = '';
         let kind = '';
-        if (i.type) {
+        if (i.type && i.kind.toUpperCase() !== 'FULLTEXT') {
           type = 'USING ' + i.type;
         }
         if (i.kind) {


### PR DESCRIPTION
Signed-off-by: FORNO <forno@xmaho.link>

Implements #470 

##  Result of test on my machine

```
  1978 passing (1m)
  216 pending
  3 failing
```

```
  1) MySQL datetime handling
       should allow use of fractional seconds:

      AssertionError: expected '1971-06-22T03:34:56.789Z' to equal '1971-06-22T12:34:56.789Z'
      + expected - actual

      -1971-06-22T03:34:56.789Z
      +1971-06-22T12:34:56.789Z
```

```
  2) MySQL connector
       should auto migrate/update foreign keys in tables:

      Uncaught AssertionError: expected 0 to be 1
      + expected - actual

      -0
      +1
```

```
3) MySQL connector
       should auto migrate/update foreign keys with onUpdate and onDelete in tables:

      Uncaught AssertionError: expected 0 to be 1
      + expected - actual

      -0
      +1
```

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
