### PR TITLE
fix: parse some options to boolean

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -310,6 +310,24 @@ function mixinDiscovery(MySQL, mysql) {
     const columnType = columnDefinition.columnType;
     const dataLength = columnDefinition.dataLength;
 
+    // when options are received here the treatTINYINT1AsTinyInt comes as a string
+    if (typeof options.treatCHAR1AsString === 'string') {
+      options.treatCHAR1AsString =
+        options.treatCHAR1AsString === 'true';
+    }
+
+    // when options are received here the treatBIT1AsBit comes as a string
+    if (typeof options.treatBIT1AsBit === 'string') {
+      options.treatBIT1AsBit =
+        options.treatBIT1AsBit === 'true';
+    }
+
+    // when options are received here the treatTINYINT1AsTinyInt comes as a string
+    if (typeof options.treatTINYINT1AsTinyInt === 'string') {
+      options.treatTINYINT1AsTinyInt =
+        options.treatTINYINT1AsTinyInt === 'true';
+    }
+
     const type = mysqlType.toUpperCase();
     switch (type) {
       case 'CHAR':

--- a/test/mysql.discover.test.js
+++ b/test/mysql.discover.test.js
@@ -357,6 +357,39 @@ describe('Discover and build models', function() {
       }
     });
 
+    context('with flag treatCHAR1AsString = "true"', function() {
+      let models, schema;
+      before(discoverAndBuildModels);
+
+      it('handles CHAR(1) as String', function() {
+        assert(schema.properties.enabled);
+        assert.strictEqual(schema.properties.enabled.type, String);
+      });
+
+      it('handles BIT(1) as Binary', function() {
+        assert(schema.properties.disabled);
+        assert.strictEqual(schema.properties.disabled.type, Buffer);
+      });
+
+      it('handles TINYINT(1) as Number', function() {
+        assert(schema.properties.active);
+        assert.strictEqual(schema.properties.active.type, Number);
+      });
+
+      function discoverAndBuildModels(done) {
+        db.discoverAndBuildModels('INVENTORY', {
+          owner: 'STRONGLOOP',
+          visited: {},
+          associations: true,
+          treatCHAR1AsString: 'true',
+        }, function(err, models_) {
+          models = models_;
+          schema = models.Inventory.definition;
+          done(err);
+        });
+      }
+    });
+
     context('with flag treatBIT1AsBit = false', function() {
       let models, schema;
       before(discoverAndBuildModels);
@@ -390,6 +423,39 @@ describe('Discover and build models', function() {
       }
     });
 
+    context('with flag treatBIT1AsBit = "false"', function() {
+      let models, schema;
+      before(discoverAndBuildModels);
+
+      it('handles CHAR(1) as Boolean', function() {
+        assert(schema.properties.enabled);
+        assert.strictEqual(schema.properties.enabled.type, Boolean);
+      });
+
+      it('handles BIT(1) as Boolean', function() {
+        assert(schema.properties.disabled);
+        assert.strictEqual(schema.properties.disabled.type, Boolean);
+      });
+
+      it('handles TINYINT(1) as Number', function() {
+        assert(schema.properties.active);
+        assert.strictEqual(schema.properties.active.type, Number);
+      });
+
+      function discoverAndBuildModels(done) {
+        db.discoverAndBuildModels('INVENTORY', {
+          owner: 'STRONGLOOP',
+          visited: {},
+          associations: true,
+          treatBIT1AsBit: 'false',
+        }, function(err, models_) {
+          models = models_;
+          schema = models.Inventory.definition;
+          done(err);
+        });
+      }
+    });
+
     context('with flag treatTINYINT1AsTinyInt = false', function() {
       let models, schema;
       before(discoverAndBuildModels);
@@ -415,6 +481,40 @@ describe('Discover and build models', function() {
           visited: {},
           associations: true,
           treatTINYINT1AsTinyInt: false,
+        }, function(err, models_) {
+          if (err) return done(err);
+          models = models_;
+          schema = models.Inventory.definition;
+          done();
+        });
+      }
+    });
+
+    context('with flag treatTINYINT1AsTinyInt = "false"', function() {
+      let models, schema;
+      before(discoverAndBuildModels);
+
+      it('handles CHAR(1) as Boolean', function() {
+        assert(schema.properties.enabled);
+        assert.strictEqual(schema.properties.enabled.type, Boolean);
+      });
+
+      it('handles BIT(1) as Binary', function() {
+        assert(schema.properties.disabled);
+        assert.strictEqual(schema.properties.disabled.type, Buffer);
+      });
+
+      it('handles TINYINT(1) as Boolean', function() {
+        assert(schema.properties.active);
+        assert.strictEqual(schema.properties.active.type, Boolean);
+      });
+
+      function discoverAndBuildModels(done) {
+        db.discoverAndBuildModels('INVENTORY', {
+          owner: 'STRONGLOOP',
+          visited: {},
+          associations: true,
+          treatTINYINT1AsTinyInt: 'false',
         }, function(err, models_) {
           if (err) return done(err);
           models = models_;


### PR DESCRIPTION
This PR is related to [this](https://github.com/loopbackio/loopback-next/pull/9128) PR at loopback-next. The values received from lb4 cli for the options: treatCHAR1AsString, treatBIT1AsBit, and treatTINYINT1AsTinyInt are strings. Here they are being changed to boolean values.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
