### PR TITLE
ci: update ci runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    # ubuntu support dropped due to https://github.com/ankane/setup-mysql/commit/70636bf8d2c54521a1b871af766b58d76b468d94
+    runs-on: macos-12
     strategy:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "loopback-connector-mysql",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.0",


### PR DESCRIPTION
Due to removal of support for ubuntu 18 from https://github.com/ankane/setup-mysql in this [PR](https://github.com/ankane/setup-mysql/commit/70636bf8d2c54521a1b871af766b58d76b468d94), our CI checks are failing.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
