### PR TITLE
add order by ordinal position for query columns

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -154,7 +154,7 @@ function mixinDiscovery(MySQL, mysql) {
    * @param table
    * @returns {String} The sql statement
    */
-  MySQL.prototype.buildQueryColumns = function(schema, table) {
+  MySQL.prototype.buildQueryColumns = function(schema, table, options = {}) {
     let sql = null;
     if (schema) {
       sql = paginateSQL('SELECT table_schema AS "owner",' +
@@ -185,6 +185,9 @@ function mixinDiscovery(MySQL, mysql) {
         ' FROM information_schema.columns' +
         (table ? ' WHERE table_name=' + mysql.escape(table) : ''),
       'table_name, ordinal_position', {});
+    }
+    if (options.orderBy) {
+      sql += ' ORDER BY ' + options.orderBy;
     }
     return sql;
   };

--- a/test/mysql.discover.test.js
+++ b/test/mysql.discover.test.js
@@ -126,6 +126,32 @@ describe('Discover models including other users', function() {
 });
 
 describe('Discover model properties', function() {
+  describe('Discover model properties in Ordinal Order', function() {
+    it('should return an array of columns for product in ordinal order', function(done) {
+      const productProperties = [];
+      const productPropertiesInOrdinalOrder = [
+        'ID',
+        'NAME',
+        'AUDIBLE_RANGE',
+        'EFFECTIVE_RANGE',
+        'ROUNDS',
+        'EXTRAS',
+        'FIRE_MODES',
+      ];
+      db.discoverModelProperties('PRODUCT', {orderBy: 'ordinal_position'}, function(err, models) {
+        if (err) {
+          console.error(err);
+          done(err);
+        } else {
+          models.forEach(function(m) { productProperties.push(m.columnName); });
+          productProperties.forEach((prop, index) => {
+            assert(productPropertiesInOrdinalOrder[index] === prop);
+          });
+          done(null, models);
+        }
+      });
+    });
+  });
   describe('Discover a named model', function() {
     it('should return an array of columns for product', function(done) {
       db.discoverModelProperties('product', function(err, models) {


### PR DESCRIPTION
lb4 discover analyses the table structures for MySQL using INFORMATION_SCHEMA.COLUMNS 
It does not seem to use the ordinal when reading the columns.

This PR adds the order by ordinal_order.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
