### PR TITLE
fix: return enum type

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -340,7 +340,6 @@ function mixinDiscovery(MySQL, mysql) {
       case 'MEDIUMTEXT':
       case 'LONGTEXT':
       case 'TEXT':
-      case 'ENUM':
       case 'SET':
         return 'String';
       case 'TINYBLOB':
@@ -380,6 +379,8 @@ function mixinDiscovery(MySQL, mysql) {
       case 'BOOL':
       case 'BOOLEAN':
         return 'Boolean';
+      case 'ENUM':
+        return columnType;
       default:
         return 'String';
     }

--- a/test/mysql.discover.test.js
+++ b/test/mysql.discover.test.js
@@ -257,6 +257,22 @@ describe('Discover LDL schema from a table', function() {
   });
 });
 
+describe('Discover and handle enum', function() {
+  let schema;
+  before(function(done) {
+    db.discoverSchema('PATIENT', {owner: 'STRONGLOOP'}, function(err, schema_) {
+      schema = schema_;
+      done(err);
+    });
+  });
+  it('should validate enum type for PATIENT', function() {
+    assert.ok(/STRONGLOOP/i.test(schema.options.mysql.schema));
+    assert.strictEqual(schema.options.mysql.table, 'PATIENT');
+    assert.strictEqual(schema.name, 'Patient');
+    assert.strictEqual(schema.properties.type.type, "enum('INPATIENT','OUTPATIENT')");
+  });
+});
+
 describe('Discover and build models', function() {
   let models;
   before(function(done) {

--- a/test/schema.sql
+++ b/test/schema.sql
@@ -49,6 +49,23 @@ LOCK TABLES `CUSTOMER` WRITE;
 /*!40000 ALTER TABLE `CUSTOMER` ENABLE KEYS */;
 UNLOCK TABLES;
 
+
+--
+-- Table structure for table `INVENTORY`
+--
+
+DROP TABLE IF EXISTS `PATIENT`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `PATIENT` (
+  `ID` varchar(20) NOT NULL,
+  `NAME` varchar(20) NOT NULL,
+  `TYPE` ENUM('INPATIENT', 'OUTPATIENT') DEFAULT NULL,
+  PRIMARY KEY (`ID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+
 --
 -- Table structure for table `INVENTORY`
 --


### PR DESCRIPTION
`lb4 discover` doesn't handle enum properly. This PR implements [this](https://loopback.io/doc/en/lb4/Model.html#enum-property) workaround for the enum in `lb4 discover`. For that to work, MySQL connector needs to return the `enum` type as it is.

Related GitHub issues & PRs:

PR https://github.com/loopbackio/loopback-next/pull/10065

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
