### PR TITLE
fix: remove generator specific options to mysql2 pool.

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -108,6 +108,28 @@ MySQL.prototype.connect = function(callback) {
 
 function generateOptions(settings) {
   const s = settings || {};
+  const generatorSpecificOptions = [
+    'name',
+    'connector',
+    'sharedData',
+    'forwardErrorToEnvironment',
+    'skipLocalCache',
+    '_',
+    'c',
+    'y',
+    'initialGenerator',
+    'resolved',
+    'namespace',
+    'skip-cache',
+    'skip-install',
+    'force-install',
+    'ask-answered',
+    'config',
+    'yes',
+    'url',
+    'engine',
+    'collation',
+  ];
   if (s.collation) {
     // Charset should be first 'chunk' of collation.
     s.charset = s.collation.substr(0, s.collation.indexOf('_'));
@@ -148,7 +170,10 @@ function generateOptions(settings) {
     // Take other options for mysql driver
     // See https://github.com/loopbackio/loopback-connector-mysql/issues/46
     for (const p in s) {
-      if (p === 'database' && s.createDatabase) {
+      if (
+        (p === 'database' && s.createDatabase) ||
+        generatorSpecificOptions.includes(p)
+      ) {
         continue;
       }
       if (options[p] === undefined) {


### PR DESCRIPTION
The connector throws following warnings while running the `lb4 discover` & starting the app. 

```---
Ignoring invalid configuration option passed to Connection: name. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: connector. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: sharedData. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: forwardErrorToEnvironment. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: skipLocalCache. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: _. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: config. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: yes. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: initialGenerator. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: resolved. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: namespace. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: skip-cache. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: skip-install. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: force-install. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: ask-answered. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: c. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: y. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: url. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
Ignoring invalid configuration option passed to Connection: collation. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
```

This PR fixes this error.

The reason it shows up is that the new mysql2 doesn't allow any extra option. While the configs passed in have options that are related to generators.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
