### PR TITLE
fix: reading error code

### DIFF
--- a/lib/set-http-code.js
+++ b/lib/set-http-code.js
@@ -26,6 +26,8 @@ const codes = {
  * add your SQL error to the correct HTTP code array above!
  */
 module.exports = function(err) {
+  let code = '';
+  if (err && err.code) code = err.code;
   if (!err) {
     return;
   } else if (!(err instanceof Error)) {
@@ -33,7 +35,7 @@ module.exports = function(err) {
   }
   // Find error prefix
   const msg = err.message;
-  const sqlError = msg.substring(0, msg.indexOf(':'));
+  const sqlError = msg.substring(0, msg.indexOf(':')) || code;
 
   for (const code in codes) {
     if (_.includes(codes[code], sqlError)) {

--- a/test/set-http-code.test.js
+++ b/test/set-http-code.test.js
@@ -29,6 +29,18 @@ describe('setHttpCode', function() {
       });
     }
   });
+
+  it('should set statusCode from code', function() {
+    let err = {
+      message: 'Duplicate entry \'value\' for key \'key_name\'',
+      code: 'ER_DUP_ENTRY',
+    };
+    err = setHttpCode(err);
+    should.exist(err.statusCode);
+    should(err instanceof Error);
+    should.equal(err.statusCode, 422);
+  });
+
   it('should do nothing without error', function() {
     should.doesNotThrow(setHttpCode);
   });


### PR DESCRIPTION
When the connector fails due to duplicate entry, it fails to status code to 500 hence the app returns Internal Server Error. This PR fixes that.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
