### PR TITLE
fix: mark primary key auto-increment only if column type is INT

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -628,7 +628,13 @@ function mixinMigration(MySQL, mysql) {
       if (pks.length === 1) {
         const idName = this.idName(model);
         const idProp = this.getModelDefinition(model).properties[idName];
-        if (idProp.generated) {
+        const idColumnType = this.columnDataType(model, idName);
+        if (idProp.generated && (
+          idColumnType === 'TINYINT' ||
+          idColumnType === 'SMALLINT' ||
+          idColumnType === 'MEDIUMINT' ||
+          idColumnType === 'INT' ||
+          idColumnType === 'BIGINT')) {
           sql.push(self.columnEscaped(model, idName) + ' ' +
             self.buildColumnDefinition(model, idName) + ' AUTO_INCREMENT PRIMARY KEY');
         } else {


### PR DESCRIPTION
This PR marks an id property autoincrement only when type of the id property is integer/number.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
