### PR TITLE
Upgrading to mysql2 to handle mysql8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 *.xml
 .loopbackrc
 .idea
+package-lock.json

--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -1,7 +1,7 @@
 /*!
  * Module dependencies
  */
-var mysql = require('mysql');
+var mysql = require('mysql2');
 
 var SqlConnector = require('loopback-connector').SqlConnector;
 var ParameterizedSQL = SqlConnector.ParameterizedSQL;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "async": "^0.9.0",
     "debug": "^2.1.1",
     "loopback-connector": "^2.1.0",
-    "mysql": "^2.5.4"
+    "mysql2": "^3.14.1"
   },
   "devDependencies": {
     "bluebird": "~2.9.10",


### PR DESCRIPTION
Replace mysql package with mysql2.

Mysql package is no longer support and does not work very well with MySQL 8 new authentication system.

Fixes (part of) rest-api-service#1106

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
