### PR TITLE
chore: drop Node.js 18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "7.1.5",
   "description": "MySQL connector for loopback-datasource-juggler",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "main": "index.js",
   "scripts": {
@@ -42,5 +42,5 @@
     "url": "https://github.com/loopbackio/loopback-connector-mysql.git"
   },
   "license": "MIT",
-  "author": "IBM Corp."
+  "author": "IBM Corp. and LoopBack contributors"
 }


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js 18 support

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
