### PR TITLE
fix: remove force generator specific optons to mysql2 pool

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -129,6 +129,7 @@ function generateOptions(settings) {
     'url',
     'engine',
     'collation',
+    'force',
   ];
   if (s.collation) {
     // Charset should be first 'chunk' of collation.


### PR DESCRIPTION
Fix following warning

Ignoring invalid configuration option passed to Connection: force. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection

This warning occurs because --force flag, which is automatically attached to lb4 discover command by default, gets passed down through the datasource settings to mysql2 which doesn't recognize it as a valid MySQL connection option.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
