### PR TITLE
chore: drop Node.js 20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
@@ -39,10 +39,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 20.20.2
+          node-version: 24
       - name: Bootstrap project
         run: |
           npm ci --ignore-scripts
@@ -57,10 +57,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 20.20.2
+          node-version: 24
       - name: Bootstrap project
         run: |
           npm ci --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.9",
   "description": "MySQL connector for loopback-datasource-juggler",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Node.js 20 has reached end of life ([link](https://github.com/nodejs/Release)), so dropping its support in this module.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
